### PR TITLE
Replaced .json() calls .json property gets.

### DIFF
--- a/trello-backup.py
+++ b/trello-backup.py
@@ -60,7 +60,6 @@ def main():
 	boardPayload = {
 		'key':API_KEY,
 		'token':TOKEN,
-		'lists':'open',
 		'fields':'all',
 		'actions':'all',
 		'action_fields':'all',
@@ -78,7 +77,7 @@ def main():
 	}
 	boards = requests.get(API_URL + "members/me/boards", params=boardsPayload)
 	try:
-		if len(boards.json()) <= 0:
+		if len(boards.json) <= 0:
 			print('No boards found.')
 			return
 	except ValueError:
@@ -90,7 +89,7 @@ def main():
 	print('Backing up boards:')
 	epoch_time = str(int(time.time()))
 
-	for board in boards.json():
+	for board in boards.json:
 		if ORGANIZATION_IDS and (not board["idOrganization"] or not board["idOrganization"] in ORGANIZATION_IDS):
 			continue
 
@@ -98,7 +97,7 @@ def main():
 		boardContents = requests.get(API_URL + "boards/" + board["id"], params=boardPayload)
 		with io.open(OUTPUT_DIRECTORY + u'/{0}_'.format(board["name"].replace("/","-")) + epoch_time + '.json', 'w', encoding='utf8') as file:
 			args = dict( sort_keys=True, indent=4) if PRETTY_PRINT else dict()
-			data = json.dumps(boardContents.json(), ensure_ascii=False, **args)
+			data = json.dumps(boardContents.json, ensure_ascii=False, **args)
 			file.write(unicode(data))
 
 def get_organization_ids(ORGANIZATION_NAMES):
@@ -114,10 +113,10 @@ def get_organization_ids(ORGANIZATION_NAMES):
 	}
 
 	organizations = requests.get(API_URL + "members/my/organizations", params=organizationsPayload)
-	if len(organizations.json()) <= 0:
+	if len(organizations.json) <= 0:
 		print('No organizations found.')
 	else:
-		for organization in organizations.json():
+		for organization in organizations.json:
 			if organization["name"] in selected_organizations:
 				organization_ids.append(organization["id"])
 	return organization_ids


### PR DESCRIPTION
We'd been using this script for a long time (thanks!) and last year it started failing.  The error was, for example...

```
Traceback (most recent call last):
  File "trello-backup.py", line 127, in <module>
    main()
  File "trello-backup.py", line 81, in main
    if len(boards.json()) <= 0:
TypeError: 'list' object is not callable
```

It seems that Request.json is actually an object property, not a method (at least on my system).  After making the modifications seen in this commit, the script started working again.

Also, 'lists' is repeated in the boardPayload object, so I've removed the first instance.